### PR TITLE
fixing the link to wiki7500 tar file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Process:
 Resources:
 - Logic is in [`densePhrases.scripts.sampler.py`](densephrases/scripts/sampler.py).
 - Notebook with EDA is at [wikidump-sampler.ipynb](wikidump-sampler.ipynb)
-- Data can be downloaded [here](https://www.dropbox.com/s/ntr2fvhzxrjioq2/wiki7500.tar.gz?dl=0) or just use `wget`:
+- Data can be downloaded [here](https://www.dropbox.com/s/4d45t8x4dsue7vy/wiki7500.tar.gz?dl=0) or just use `wget`:
 ```
-wget https://www.dropbox.com/s/ntr2fvhzxrjioq2/wiki7500.tar.gz?raw=1
+wget -O wiki7500.tar.gz https://www.dropbox.com/s/4d45t8x4dsue7vy/wiki7500.tar.gz?raw=1
+tar -xvf wiki7500.tar.gz
 ```
 
 ## Original README starts here

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Process:
 Resources:
 - Logic is in [`densePhrases.scripts.sampler.py`](densephrases/scripts/sampler.py).
 - Notebook with EDA is at [wikidump-sampler.ipynb](wikidump-sampler.ipynb)
-- Data can be downloaded [here](https://www.dropbox.com/s/m1j6mry32o55j2i/wiki7500.tar.gz?dl=0) or just use `wget`:
+- Data can be downloaded [here](https://www.dropbox.com/s/ntr2fvhzxrjioq2/wiki7500.tar.gz?dl=0) or just use `wget`:
 ```
-wget https://www.dropbox.com/s/m1j6mry32o55j2i/wiki7500.tar.gz?raw=1
+wget https://www.dropbox.com/s/ntr2fvhzxrjioq2/wiki7500.tar.gz?raw=1
 ```
 
 ## Original README starts here

--- a/densephrases/scripts/sampler.py
+++ b/densephrases/scripts/sampler.py
@@ -275,9 +275,9 @@ class QAWikiDumpSampler:
         Path(dump_folder).mkdir(exist_ok=True)
         for start in range(n // chunk_size + int(n % chunk_size > 0)):
             dump_chunk = {
-                "data": rows[start * chunk_size : min((start + 1) * chunk_size, n)]
+                "data": rows[start * chunk_size: min((start + 1) * chunk_size, n)]
             }
-            json.dump(dump_chunk, open(f"{dump_folder}/{start}", "w"))
+            json.dump(dump_chunk, open(f"{dump_folder}/{start:04d}", "w"))
 
     def _query_top_indices(self, query: str, top_n: int) -> Iterable[int]:
         query_tokenized = self._tokenize(query)

--- a/wikidump-sampler.ipynb
+++ b/wikidump-sampler.ipynb
@@ -1186,7 +1186,7 @@
    },
    "outputs": [],
    "source": [
-    "!tar -czf wiki7500.tar.gz wiki_cache"
+    "!mv wiki_dump wiki7500 && tar -czf wiki7500.tar.gz wiki7500"
    ]
   },
   {


### PR DESCRIPTION
zipped the wrong folder, fixing the dropbox link.

if you haven't used this link you're good. in case you have you need to re-download and expand the tar file. sorry.

@atemaguer @woffett 